### PR TITLE
Support Ruby 2.4's Integer class, Fixnum has been deprecated

### DIFF
--- a/lib/to_words.rb
+++ b/lib/to_words.rb
@@ -25,7 +25,8 @@ module ToWords
   end
 end
 
-class Fixnum
+INTEGER_KLASS = 1.class # Fixnum before Ruby 2.4, Integer from Ruby 2.4
+class INTEGER_KLASS
   include ToWords
 end
 

--- a/spec/to_words/under_hundred_spec.rb
+++ b/spec/to_words/under_hundred_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "UNDER_HUNDRED" do
   it { is_expected.to be_a Hash }
 
   it "has all keys to be integers" do
-    expect(subject.keys.all? { |key| key.is_a? Fixnum }).to be true
+    integer_class = 1.class # Fixnum before Ruby 2.4, Integer from Ruby 2.4
+    expect(subject.keys.all? { |key| key.is_a? integer_class }).to be true
   end
 
   it "has all values to be strings" do

--- a/spec/to_words_spec.rb
+++ b/spec/to_words_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe "to_word" do
       expect { "d1".to_words }.to raise_error "A whole number is expected"
     end
 
-    it "it extends Fixnum methods" do
+    it "it extends Fixnum / Integer methods" do
+       # Fixnum before Ruby 2.4, Integer from Ruby 2.4
       expect(1.methods).to include :to_words
     end
   end


### PR DESCRIPTION
At the moment, it spits out deprecation errors